### PR TITLE
Update parser.js

### DIFF
--- a/frontend/src/utils/loot/parser.js
+++ b/frontend/src/utils/loot/parser.js
@@ -24,7 +24,7 @@
 const moment = require('moment');
 
 function getNumber(name, data) {
-  const re = new RegExp(`.*${name}:`, 'g');
+  const re = new RegExp(`.*${name} `, 'g');
 
   return parseInt(data.replace(re, '').replace(/,/g, ''), 10);
 }
@@ -82,7 +82,7 @@ function parse(partyHunt) {
       }
 
       if (data.includes('Session')) {
-        hunt.session = parseSession(data.replace('Session: ', ''));
+        hunt.session = parseSession(data.replace('Session ', ''));
 
         return;
       }


### PR DESCRIPTION
Parser is breaking because ":" is not used anymore, only in Loot Type.

Example:

```
Session data: From 2021-07-12, 22:58:17 to 2021-07-13, 01:40:46
Session 02:42h
Loot Type: Leader
Loot 11,691,252
Supplies 7,655,672
Balance 4,035,580
LLL
	Loot 344,009
	Supplies 514,270
	Balance -170,261
	Damage 8,383,169
	Healing 324,529
ZZZ
	Loot 274,550
	Supplies 850,690
	Balance -576,140
	Damage 10,973,283
	Healing 519,687
XX
	Loot 435,264
	Supplies 1,316,161
	Balance -880,897
	Damage 7,895,908
	Healing 5,404,704
XX
	Loot 0
	Supplies 1,379,756
	Balance -1,379,756
	Damage 7,408,679
	Healing 4,291,828
YY (Leader)
	Loot 10,637,429
	Supplies 3,594,795
	Balance 7,042,634
	Damage 8,129,081
	Healing 1,962,205
```